### PR TITLE
Reduce memory usage using projection with only ids on retrieveScheduledEvents outbox method

### DIFF
--- a/packages/ddd-toolkit/src/outbox/mongo-outbox.ts
+++ b/packages/ddd-toolkit/src/outbox/mongo-outbox.ts
@@ -115,13 +115,15 @@ export class MongoOutbox implements IOutbox, IInit, ITerminate {
     }
 
     private async retrieveScheduledEvents() {
-        const scheduledEvents = await this.outboxCollection
+        const scheduledEventsIds = await this.outboxCollection
             .find({
                 status: 'scheduled',
                 contextName: this.contextName,
             })
+            .project({ _id: 1 })
+            .map((model) => model._id.toString())
             .toArray();
-        return scheduledEvents.map((event) => event._id.toString());
+        return scheduledEventsIds;
     }
 
     private async publishEventWithConcurrencyControl(eventId: string) {


### PR DESCRIPTION
# Optimize Memory Usage in Outbox Event Processing

## Summary
This PR optimizes the MongoDB query in our outbox system by implementing a projection-based approach when retrieving scheduled events. Instead of fetching complete event documents, we now only retrieve the document IDs, reducing memory usage during the event processing pipeline.

## Technical Details
- Modified the `retrieveScheduledEvents` method to use MongoDB's `.project({ _id: 1 })` feature
- Streamlined the data transformation process by directly mapping to ID strings
- Maintains existing functionality while improving resource efficiency

## Benefits
- Reduced memory footprint during event processing
- More efficient database queries
- No changes to the public API or existing behavior

## Testing
All existing tests pass without modifications.